### PR TITLE
Dynamically import repeated wordmark SVG

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -3,8 +3,12 @@ import { SLOW_DANGLE_STYLE } from '../constants/css/rotation';
 import logo from '../images/colonel.svg';
 import styled from 'styled-components';
 import { LOGO_Z_INDEX } from '../constants/z-index';
-import WordmarkRepeated from './WordmarkRepeated';
 import Image from 'next/image';
+import dynamic from 'next/dynamic';
+
+const WordmarkRepeated = dynamic(() => import('./WordmarkRepeated'), {
+  ssr: false,
+});
 
 const StyledWordmark = styled(WordmarkRepeated)`
   height: 698px;


### PR DESCRIPTION
Eliminate the footer SVG from the initial HTML response payload and retrieve it dynamically on the client as a static chunk via [`next/dynamic`](https://nextjs.org/docs/app/guides/lazy-loading#nextdynamic).

| | Transferred over network | Resource size |
|--------|--------|--------|
| [**Production**](https://www.jerrypop.com/) | `11.4 kB` | `67.5 kB` |
| [**Preview deployment**](https://435--jerrypop.netlify.app/) | `7.6 kB` | `33.2 kB` |
