### PR TITLE
Standardize component signatures and exports

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,4 @@
-import About from '../../components/About';
+import { About } from '../../components/About';
 
 export const metadata = {
   title: 'About · Jerrypop',

--- a/src/app/catering/page.tsx
+++ b/src/app/catering/page.tsx
@@ -1,4 +1,4 @@
-import Catering from '../../components/Catering';
+import { Catering } from '../../components/Catering';
 
 export const metadata = {
   title: 'Catering · Jerrypop',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,11 +3,11 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import { METADATA } from '../constants/metadata';
 import { VIEWPORT } from '../constants/viewport';
 import { isProduction } from '../utilities/environment';
-import ScrollToTopOnPathChange from '../components/ScrollToTopOnPathChange';
-import NavigationBar from '../components/NavigationBar';
-import Footer from '../components/Footer';
-import ClickPop from '../components/ClickPop';
-import ConsoleAsciiArt from '../components/ConsoleAsciiArt';
+import { ScrollToTopOnPathChange } from '../components/ScrollToTopOnPathChange';
+import { NavigationBar } from '../components/NavigationBar';
+import { Footer } from '../components/Footer';
+import { ClickPop } from '../components/ClickPop';
+import { ConsoleAsciiArt } from '../components/ConsoleAsciiArt';
 import { ReactNode } from 'react';
 
 export const metadata = METADATA;

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import NotFound from '../components/NotFound';
+import { NotFound } from '../components/NotFound';
 
 export const metadata = {
   title: 'Page Not Found · Jerrypop',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import Home from '../components/Home';
+import { Home } from '../components/Home';
 
 export default function Page() {
   return <Home />;

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,4 +1,4 @@
-import Products from '../../components/Products';
+import { Products } from '../../components/Products';
 
 export const metadata = {
   title: 'Products · Jerrypop',

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,4 +1,4 @@
-import Recipes from '../../components/Recipes';
+import { Recipes } from '../../components/Recipes';
 
 export const metadata = {
   title: 'Recipes · Jerrypop',

--- a/src/app/retail/page.tsx
+++ b/src/app/retail/page.tsx
@@ -1,4 +1,4 @@
-import Retail from '../../components/Retail';
+import { Retail } from '../../components/Retail';
 
 export const metadata = {
   title: 'Retail · Jerrypop',

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import PageHeaderPhotographSrc from '../images/glamorous-blueberry-pancake.jpeg';
-import Team from './Team';
-import PageContentLayout from './PageContentLayout';
-import Heading1 from './common/Heading1';
-import Paragraph from './common/Paragraph';
-import Heading2 from './common/Heading2';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
+import { Team } from './Team';
+import { PageContentLayout } from './PageContentLayout';
+import { Heading1 } from './common/Heading1';
+import { Paragraph } from './common/Paragraph';
+import { Heading2 } from './common/Heading2';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
 
-const About = () => {
+export function About() {
   return (
     <>
       <PageHeaderPhotograph
@@ -39,6 +39,4 @@ const About = () => {
       </PageContentLayout>
     </>
   );
-};
-
-export default About;
+}

--- a/src/components/Catering.tsx
+++ b/src/components/Catering.tsx
@@ -1,26 +1,26 @@
 'use client';
 
 import { CATERING_PRODUCTS } from '../constants/product';
-import Heading1 from './common/Heading1';
-import Heading2 from './common/Heading2';
-import Paragraph from './common/Paragraph';
+import { Heading1 } from './common/Heading1';
+import { Heading2 } from './common/Heading2';
+import { Paragraph } from './common/Paragraph';
 import PageHeaderPhotographSrc from '../images/glamorous-chocolate-hazelnut-espresso.jpeg';
 import Link from 'next/link';
-import FormDialog from './FormDialog';
+import { FormDialog } from './FormDialog';
 import { useDialogState } from '../hooks/use-dialog-state';
 import {
   CATERING_ORDER_FORM_SRC,
   CATERING_ORDER_FORM_TITLE,
 } from '../constants/form';
-import PageContentLayout from './PageContentLayout';
-import Button from './common/Button';
-import DefinitionList from './common/DefinitionList';
-import DescriptionTerm from './common/DescriptionTerm';
-import DescriptionDetails from './common/DescriptionDetails';
-import ProductPricingList from './common/ProductPricingList';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
+import { PageContentLayout } from './PageContentLayout';
+import { Button } from './common/Button';
+import { DefinitionList } from './common/DefinitionList';
+import { DescriptionTerm } from './common/DescriptionTerm';
+import { DescriptionDetails } from './common/DescriptionDetails';
+import { ProductPricingList } from './common/ProductPricingList';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
 
-const Catering = () => {
+export function Catering() {
   const { closeDialog, isFormVisible, openDialog } = useDialogState();
 
   return (
@@ -88,6 +88,4 @@ const Catering = () => {
       )}
     </>
   );
-};
-
-export default Catering;
+}

--- a/src/components/ClickPop.tsx
+++ b/src/components/ClickPop.tsx
@@ -2,7 +2,7 @@
 
 import { useClickPop } from '../hooks/use-click-pop';
 
-export default function ClickPop() {
+export function ClickPop() {
   useClickPop();
   return <></>;
 }

--- a/src/components/ConsoleAsciiArt.tsx
+++ b/src/components/ConsoleAsciiArt.tsx
@@ -2,7 +2,7 @@
 
 import { useConsoleAsciiArt } from '../hooks/use-console-ascii-art';
 
-export default function ConsoleAsciiArt() {
+export function ConsoleAsciiArt() {
   useConsoleAsciiArt();
   return <></>;
 }

--- a/src/components/DesktopNavigationBarContent.tsx
+++ b/src/components/DesktopNavigationBarContent.tsx
@@ -5,7 +5,7 @@ import { NavigationMenuItem } from '../types/navigation';
 import WordmarkSvgDark from '../images/jerrypop-wordmark-soft-white.svg';
 import Image from 'next/image';
 
-export default function DesktopNavigationBarContent({
+export function DesktopNavigationBarContent({
   navigationMenuItems,
 }: {
   navigationMenuItems: NavigationMenuItem[];

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import SocialLinks from './SocialLinks';
-import Logo from './Logo';
+import { SocialLinks } from './SocialLinks';
+import { Logo } from './Logo';
 import { useJerrypopTheme } from '../hooks/use-jerrypop-theme';
 import { increaseKernelCount } from '../utilities/click-pop';
 
-const Footer = () => {
+export function Footer() {
   const [jerrypopTheme, incrementJerrypopTheme] = useJerrypopTheme();
 
   return (
@@ -36,6 +36,4 @@ const Footer = () => {
       </div>
     </footer>
   );
-};
-
-export default Footer;
+}

--- a/src/components/FormDialog.tsx
+++ b/src/components/FormDialog.tsx
@@ -1,18 +1,20 @@
 import { useWindowSize } from '../hooks/use-window-size';
-import CloseIcon from './icons/CloseIcon';
+import { CloseIcon } from './icons/CloseIcon';
 
 const DIALOG_HEADER_HEIGHT_PX = 52; // Height of header with close button
 const VERTICAL_MARGIN_PX = 8; // Vertial margin of entire dialog
 const HORIZONTAL_MARGIN_PX = 8; // Horizontal margin of entire dialog
 const MINIMUM_DIALOG_HEIGHT = 150;
 
-interface Props {
+export function FormDialog({
+  onCloseFormDialog,
+  src,
+  title,
+}: {
   onCloseFormDialog: () => void;
   src: string;
   title: string;
-}
-
-const FormDialog = ({ onCloseFormDialog, src, title }: Props) => {
+}) {
   const { innerHeight, innerWidth } = useWindowSize();
   const dialogHeight = Math.max(
     innerHeight - 2 * VERTICAL_MARGIN_PX,
@@ -65,6 +67,4 @@ const FormDialog = ({ onCloseFormDialog, src, title }: Props) => {
       />
     </>
   );
-};
-
-export default FormDialog;
+}

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,19 +1,19 @@
 'use client';
 
-import Heading1 from './common/Heading1';
-import Paragraph from './common/Paragraph';
+import { Heading1 } from './common/Heading1';
+import { Paragraph } from './common/Paragraph';
 import PageHeaderPhotographSrc from '../images/glamorous-habanero-ranch.jpeg';
-import PressArticles from './PressArticles';
+import { PressArticles } from './PressArticles';
 import Link from 'next/link';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
-import PageContentLayout from './PageContentLayout';
-import ButtonLink from './common/ButtonLink';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
+import { PageContentLayout } from './PageContentLayout';
+import { ButtonLink } from './common/ButtonLink';
 
 const POP_UP_REQUEST_EMAIL_SUBJECT = 'Jerrypop pop-up request';
 const POP_UP_REQUEST_EMAIL_BODY =
   "Hi Jerrypop,\n\nI'd like for you to pop up at [my event] at [location] on [date] from [time range]. Are you available?\n\nThanks,\n[name]";
 
-const Home = () => {
+export function Home() {
   const encodedEmailSubject = encodeURIComponent(POP_UP_REQUEST_EMAIL_SUBJECT);
   const encodedEmailBody = encodeURIComponent(POP_UP_REQUEST_EMAIL_BODY);
   const requestPopUpHref = `mailto:info@jerrypop.com?subject=${encodedEmailSubject}&body=${encodedEmailBody}`;
@@ -60,6 +60,4 @@ const Home = () => {
       <PressArticles />
     </>
   );
-};
-
-export default Home;
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -7,12 +7,13 @@ const WordmarkRepeated = dynamic(() => import('./WordmarkRepeated'), {
   ssr: false,
 });
 
-interface Props {
+export function Logo({
+  onToggleTheme,
+  theme,
+}: {
   onToggleTheme: () => void;
   theme: Theme;
-}
-
-const Logo = ({ onToggleTheme, theme }: Props) => {
+}) {
   return (
     <>
       <WordmarkRepeated
@@ -34,6 +35,4 @@ const Logo = ({ onToggleTheme, theme }: Props) => {
       </button>
     </>
   );
-};
-
-export default Logo;
+}

--- a/src/components/MobileNavigationBarContent.tsx
+++ b/src/components/MobileNavigationBarContent.tsx
@@ -5,10 +5,10 @@ import { useEffect, useState } from 'react';
 import WordmarkSvgDark from '../images/jerrypop-wordmark-soft-white.svg';
 import { NavigationMenuItem } from '../types/navigation';
 import Image from 'next/image';
-import HamburgerIcon from './icons/HamburgerIcon';
-import CloseIcon from './icons/CloseIcon';
+import { HamburgerIcon } from './icons/HamburgerIcon';
+import { CloseIcon } from './icons/CloseIcon';
 
-export default function MobileNavigationBarContent({
+export function MobileNavigationBarContent({
   navigationMenuItems,
 }: {
   navigationMenuItems: NavigationMenuItem[];

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,8 +1,8 @@
-import DesktopNavigationBarContent from './DesktopNavigationBarContent';
-import MobileNavigationBarContent from './MobileNavigationBarContent';
+import { DesktopNavigationBarContent } from './DesktopNavigationBarContent';
+import { MobileNavigationBarContent } from './MobileNavigationBarContent';
 import { NAVIGATION_MENU_ITEMS } from '../constants/navigation';
 
-export default function NavigationBar() {
+export function NavigationBar() {
   return (
     <nav>
       <DesktopNavigationBarContent

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import Heading1 from './common/Heading1';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
+import { Heading1 } from './common/Heading1';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
 import PageHeaderPhotographSrc from '../images/glamorous-pbj-sheet.jpeg';
-import Paragraph from './common/Paragraph';
-import PageContentLayout from './PageContentLayout';
+import { Paragraph } from './common/Paragraph';
+import { PageContentLayout } from './PageContentLayout';
 
-const NotFound = () => {
+export function NotFound() {
   return (
     <>
       <PageHeaderPhotograph
@@ -22,6 +22,4 @@ const NotFound = () => {
       </PageContentLayout>
     </>
   );
-};
-
-export default NotFound;
+}

--- a/src/components/PageContentLayout.tsx
+++ b/src/components/PageContentLayout.tsx
@@ -1,8 +1,4 @@
-export default function PageContentLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function PageContentLayout({ children }: { children: React.ReactNode }) {
   return (
     <div
       className="

--- a/src/components/PressArticles.tsx
+++ b/src/components/PressArticles.tsx
@@ -1,8 +1,8 @@
 import { ARTICLES } from '../constants/press';
-import OptimizedImage from './common/OptimizedImage';
+import { OptimizedImage } from './common/OptimizedImage';
 import Link from 'next/link';
 
-const PressArticles = () => {
+export function PressArticles() {
   return (
     <ul className="flex flex-col flex-wrap justify-center md:flex-row">
       {ARTICLES.map(
@@ -38,6 +38,4 @@ const PressArticles = () => {
       )}
     </ul>
   );
-};
-
-export default PressArticles;
+}

--- a/src/components/ProductListing.tsx
+++ b/src/components/ProductListing.tsx
@@ -1,11 +1,7 @@
 import { Product } from '../types/product';
-import OptimizedImage from './common/OptimizedImage';
+import { OptimizedImage } from './common/OptimizedImage';
 
-interface Props {
-  product: Product;
-}
-
-const ProductListing = ({ product }: Props) => {
+export function ProductListing({ product }: { product: Product }) {
   const { allergens, description, image, ingredients, subtitle, title } =
     product;
 
@@ -32,6 +28,4 @@ const ProductListing = ({ product }: Props) => {
       ) : null}
     </li>
   );
-};
-
-export default ProductListing;
+}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import ProductListing from './ProductListing';
+import { ProductListing } from './ProductListing';
 import { PRODUCTS } from '../constants/product';
-import Heading1 from './common/Heading1';
-import Paragraph from './common/Paragraph';
+import { Heading1 } from './common/Heading1';
+import { Paragraph } from './common/Paragraph';
 import PageHeaderPhotographSrc from '../images/glamorous-mala-lime.jpeg';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
-import PageContentLayout from './PageContentLayout';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
+import { PageContentLayout } from './PageContentLayout';
 
-const Products = () => {
+export function Products() {
   return (
     <>
       <PageHeaderPhotograph
@@ -30,6 +30,4 @@ const Products = () => {
       </ul>
     </>
   );
-};
-
-export default Products;
+}

--- a/src/components/Recipe.tsx
+++ b/src/components/Recipe.tsx
@@ -1,12 +1,8 @@
 import { useState } from 'react';
-import { Recipe } from '../types/recipe';
-import Heading4 from './common/Heading4';
+import type { Recipe as RecipeInterface } from '../types/recipe';
+import { Heading4 } from './common/Heading4';
 
-interface Props {
-  recipe: Recipe;
-}
-
-const RecipeComponent = ({ recipe }: Props) => {
+export function Recipe({ recipe }: { recipe: RecipeInterface }) {
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   const onRecipeClick = () => {
@@ -80,6 +76,4 @@ const RecipeComponent = ({ recipe }: Props) => {
       </div>
     </li>
   );
-};
-
-export default RecipeComponent;
+}

--- a/src/components/Recipes.tsx
+++ b/src/components/Recipes.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { RECIPES } from '../constants/recipe';
-import Recipe from './Recipe';
-import Heading1 from './common/Heading1';
-import Paragraph from './common/Paragraph';
+import { Recipe } from './Recipe';
+import { Heading1 } from './common/Heading1';
+import { Paragraph } from './common/Paragraph';
 import PageHeaderPhotographSrc from '../images/glamorous-pbj-sheet.jpeg';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
-import PageContentLayout from './PageContentLayout';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
+import { PageContentLayout } from './PageContentLayout';
 
-const Recipes = () => {
+export function Recipes() {
   return (
     <>
       <PageHeaderPhotograph
@@ -27,6 +27,4 @@ const Recipes = () => {
       </PageContentLayout>
     </>
   );
-};
-
-export default Recipes;
+}

--- a/src/components/Retail.tsx
+++ b/src/components/Retail.tsx
@@ -1,26 +1,26 @@
 'use client';
 
 import { RETAIL_PRODUCTS } from '../constants/product';
-import Heading1 from './common/Heading1';
-import Heading2 from './common/Heading2';
-import Paragraph from './common/Paragraph';
+import { Heading1 } from './common/Heading1';
+import { Heading2 } from './common/Heading2';
+import { Paragraph } from './common/Paragraph';
 import PageHeaderPhotographSrc from '../images/glamorous-chipotle-cheddar.jpg';
 import Link from 'next/link';
-import FormDialog from './FormDialog';
+import { FormDialog } from './FormDialog';
 import { useDialogState } from '../hooks/use-dialog-state';
 import {
   RETAIL_ORDER_FORM_SRC,
   RETAIL_ORDER_FORM_TITLE,
 } from '../constants/form';
-import PageHeaderPhotograph from './common/PageHeaderPhotograph';
-import ProductPricingList from './common/ProductPricingList';
-import PageContentLayout from './PageContentLayout';
-import Button from './common/Button';
-import DefinitionList from './common/DefinitionList';
-import DescriptionTerm from './common/DescriptionTerm';
-import DescriptionDetails from './common/DescriptionDetails';
+import { PageHeaderPhotograph } from './common/PageHeaderPhotograph';
+import { ProductPricingList } from './common/ProductPricingList';
+import { PageContentLayout } from './PageContentLayout';
+import { Button } from './common/Button';
+import { DefinitionList } from './common/DefinitionList';
+import { DescriptionTerm } from './common/DescriptionTerm';
+import { DescriptionDetails } from './common/DescriptionDetails';
 
-const Retail = () => {
+export function Retail() {
   const { closeDialog, isFormVisible, openDialog } = useDialogState();
 
   return (
@@ -93,6 +93,4 @@ const Retail = () => {
       )}
     </>
   );
-};
-
-export default Retail;
+}

--- a/src/components/ScrollToTopOnPathChange.tsx
+++ b/src/components/ScrollToTopOnPathChange.tsx
@@ -2,9 +2,7 @@
 
 import { useScrollToTopOnPathChange } from '../hooks/use-scroll-to-top-on-path-change';
 
-const ScrollToTopOnPathChange = () => {
+export function ScrollToTopOnPathChange() {
   useScrollToTopOnPathChange();
   return <></>;
-};
-
-export default ScrollToTopOnPathChange;
+}

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -11,7 +11,7 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 
-const SocialLinks = () => {
+export function SocialLinks() {
   return (
     <ul className="flex">
       <li className="mx-1">
@@ -80,6 +80,4 @@ const SocialLinks = () => {
       </li>
     </ul>
   );
-};
-
-export default SocialLinks;
+}

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -1,10 +1,10 @@
-import Paragraph from './common/Paragraph';
+import { Paragraph } from './common/Paragraph';
 import AboutJerryPhotograph from '../images/about-jerry.jpeg';
-import OptimizedImage from './common/OptimizedImage';
+import { OptimizedImage } from './common/OptimizedImage';
 import { YOU_TUBE_CHANNEL_URL } from '../constants/url';
 import Link from 'next/link';
 
-const Team = () => {
+export function Team() {
   return (
     <ul>
       <li className="mt-6">
@@ -68,6 +68,4 @@ const Team = () => {
       </li>
     </ul>
   );
-};
-
-export default Team;
+}

--- a/src/components/WordmarkRepeated.tsx
+++ b/src/components/WordmarkRepeated.tsx
@@ -2,7 +2,7 @@ interface Props extends React.SVGProps<SVGSVGElement> {
   fillColor: string;
 }
 
-const WordmarkRepeated = ({ fillColor, ...props }: Props) => {
+export default function WordmarkRepeated({ fillColor, ...props }: Props) {
   return (
     <svg
       width="301"
@@ -49,6 +49,4 @@ const WordmarkRepeated = ({ fillColor, ...props }: Props) => {
       </g>
     </svg>
   );
-};
-
-export default WordmarkRepeated;
+}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,4 +1,4 @@
-export default function Button({
+export function Button({
   className = '',
   ...props
 }: React.ButtonHTMLAttributes<HTMLButtonElement>) {

--- a/src/components/common/ButtonLink.tsx
+++ b/src/components/common/ButtonLink.tsx
@@ -4,7 +4,7 @@ interface Props extends React.ComponentProps<typeof Link> {
   className?: string;
 }
 
-export default function ButtonLink({ className, ...props }: Props) {
+export function ButtonLink({ className, ...props }: Props) {
   return (
     <Link
       className={`

--- a/src/components/common/DefinitionList.tsx
+++ b/src/components/common/DefinitionList.tsx
@@ -1,4 +1,4 @@
-export default function DefinitionList({
+export function DefinitionList({
   ...props
 }: React.HTMLAttributes<HTMLDListElement>) {
   return <dl className="my-6 grid grid-cols-[1fr_3fr]" {...props} />;

--- a/src/components/common/DescriptionDetails.tsx
+++ b/src/components/common/DescriptionDetails.tsx
@@ -1,4 +1,4 @@
-export default function DescriptionDetails({
+export function DescriptionDetails({
   ...props
 }: React.HTMLAttributes<HTMLElement>) {
   return <dd className="my-4 ml-3 text-left" {...props} />;

--- a/src/components/common/DescriptionTerm.tsx
+++ b/src/components/common/DescriptionTerm.tsx
@@ -1,4 +1,4 @@
-export default function DescriptionTerm({
+export function DescriptionTerm({
   ...props
 }: React.HTMLAttributes<HTMLElement>) {
   return (

--- a/src/components/common/Heading1.tsx
+++ b/src/components/common/Heading1.tsx
@@ -4,7 +4,7 @@ interface Props extends React.HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;
 }
 
-export default function Heading1({ children, ...props }: Props) {
+export function Heading1({ children, ...props }: Props) {
   return (
     <h1 className="mb-3 mt-12 text-3xl font-semibold" {...props}>
       {children}

--- a/src/components/common/Heading2.tsx
+++ b/src/components/common/Heading2.tsx
@@ -4,7 +4,7 @@ interface Props extends React.HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;
 }
 
-export default function Heading2({ children, ...props }: Props) {
+export function Heading2({ children, ...props }: Props) {
   return (
     <h2 className="mb-3 mt-8 text-2xl font-semibold" {...props}>
       {children}

--- a/src/components/common/Heading3.tsx
+++ b/src/components/common/Heading3.tsx
@@ -4,7 +4,7 @@ interface Props extends React.HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;
 }
 
-export default function Heading3({ children, ...props }: Props) {
+export function Heading3({ children, ...props }: Props) {
   return (
     <h3 className="mb-3 mt-6 text-xl font-semibold" {...props}>
       {children}

--- a/src/components/common/Heading4.tsx
+++ b/src/components/common/Heading4.tsx
@@ -4,7 +4,7 @@ interface Props extends React.HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;
 }
 
-export default function Heading4({ children, ...props }: Props) {
+export function Heading4({ children, ...props }: Props) {
   return (
     <h4 className="mb-3 mt-6 font-semibold" {...props}>
       {children}

--- a/src/components/common/OptimizedImage.tsx
+++ b/src/components/common/OptimizedImage.tsx
@@ -29,7 +29,7 @@ interface Props extends ImageProps {
   widthCss: string;
 }
 
-export default function OptimizedImage({
+export function OptimizedImage({
   aspectRatioCss,
   className,
   sizes,

--- a/src/components/common/PageHeaderPhotograph.tsx
+++ b/src/components/common/PageHeaderPhotograph.tsx
@@ -1,7 +1,7 @@
 import { StaticImageData } from 'next/image';
-import OptimizedImage from './OptimizedImage';
+import { OptimizedImage } from './OptimizedImage';
 
-export default function PageHeaderPhotograph({
+export function PageHeaderPhotograph({
   alt,
   aspectRatioCss,
   src,

--- a/src/components/common/Paragraph.tsx
+++ b/src/components/common/Paragraph.tsx
@@ -4,7 +4,7 @@ interface Props extends React.HTMLAttributes<HTMLParagraphElement> {
   children: ReactNode;
 }
 
-export default function Paragraph({ children, ...props }: Props) {
+export function Paragraph({ children, ...props }: Props) {
   return (
     <p className="my-3 text-base" {...props}>
       {children}

--- a/src/components/common/ProductPricingList.tsx
+++ b/src/components/common/ProductPricingList.tsx
@@ -1,5 +1,5 @@
 import { CateringProduct, RetailProduct } from '../../types/product';
-import ProductPricingListItem from './ProductPricingListItem';
+import { ProductPricingListItem } from './ProductPricingListItem';
 
 interface CateringProps {
   products: CateringProduct[];
@@ -11,7 +11,7 @@ interface RetailProps {
   type: 'retail';
 }
 
-export default function ProductPricingList({
+export function ProductPricingList({
   products,
   type,
 }: CateringProps | RetailProps) {

--- a/src/components/common/ProductPricingListItem.tsx
+++ b/src/components/common/ProductPricingListItem.tsx
@@ -1,6 +1,6 @@
 import { CateringProduct, RetailProduct } from '../../types/product';
 import { displayCurrency } from '../../utilities/currency';
-import OptimizedImage from './OptimizedImage';
+import { OptimizedImage } from './OptimizedImage';
 
 interface CateringProps {
   product: CateringProduct;
@@ -12,7 +12,7 @@ interface RetailProps {
   type: 'retail';
 }
 
-export default function ProductPricingListItem({
+export function ProductPricingListItem({
   product,
   type,
 }: CateringProps | RetailProps) {

--- a/src/components/icons/CloseIcon.tsx
+++ b/src/components/icons/CloseIcon.tsx
@@ -1,4 +1,4 @@
-export default function CloseIcon(props: React.SVGProps<SVGSVGElement>) {
+export function CloseIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/icons/HamburgerIcon.tsx
+++ b/src/components/icons/HamburgerIcon.tsx
@@ -1,4 +1,4 @@
-export default function HamburgerIcon(props: React.SVGProps<SVGSVGElement>) {
+export function HamburgerIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Only default exports remain in lazily loaded components since there isn't great support for lazily importing named exports